### PR TITLE
Allow SQL expression with whereRaw query

### DIFF
--- a/src/QueryFilter.php
+++ b/src/QueryFilter.php
@@ -84,9 +84,9 @@ abstract class QueryFilter
     protected function like($column, $value)
     {
         if ($this->builder->getQuery()->getConnection()->getDriverName() == 'pgsql') {
-            return $this->builder->where($column, 'ILIKE', '%' . $value . '%');
+            return $this->builder->whereRaw($column . ' ILIKE \'%' . $value . '%\'');
         }
 
-        return $this->builder->where($column, 'LIKE', '%' . $value . '%');
+        return $this->builder->whereRaw($column . ' LIKE \'%' . $value . '%\'');
     }
 }


### PR DESCRIPTION
The column can be an SQL expression such as `CONCAT()`.
`whereRaw` function allow this.
