### PR TITLE
Make possible to call Builder methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # Travis CI configuration
 
+dist: trusty
+
 language: php
 
 php:
@@ -10,6 +12,6 @@ php:
 
 before_script:
   - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev
+  - php composer.phar install
 
 script: ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "illuminate/database": "5.*",
-        "illuminate/http": "5.*"
+        "illuminate/database": "~5.0",
+        "illuminate/http": "~5.0",
+        "illuminate/support": "~5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/QueryFilter.php
+++ b/src/QueryFilter.php
@@ -98,7 +98,7 @@ abstract class QueryFilter
      * @param array $arguments
      * @return mixed
      */
-    function __call($name, $arguments)
+    public function __call($name, $arguments)
     {
         if (method_exists($this->builder, $name)) {
             return call_user_func_array([$this->builder, $name], $arguments);

--- a/src/QueryFilter.php
+++ b/src/QueryFilter.php
@@ -46,11 +46,10 @@ abstract class QueryFilter
         }
 
         foreach ($this->filters() as $name => $value) {
-            if (!method_exists($this, camel_case($name))) {
-                continue;
+            $methodName = camel_case($name);
+            if (method_exists($this, $methodName)) {
+                call_user_func_array([$this, $methodName], array_filter([$value]));
             }
-
-            call_user_func_array([$this, camel_case($name)], array_filter([$value]));
         }
 
         return $this->builder;

--- a/src/QueryFilter.php
+++ b/src/QueryFilter.php
@@ -92,4 +92,16 @@ abstract class QueryFilter
 
         return $this->builder->where($column, 'LIKE', '%' . $value . '%');
     }
+
+    /**
+     * @param string $name
+     * @param array $arguments
+     * @return mixed
+     */
+    function __call($name, $arguments)
+    {
+        if (method_exists($this->builder, $name)) {
+            return call_user_func_array([$this->builder, $name], $arguments);
+        }
+    }
 }

--- a/tests/Filters/PostWhereFilter.php
+++ b/tests/Filters/PostWhereFilter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kblais\QueryFilter\Tests\Filters;
+
+use Kblais\QueryFilter\QueryFilter;
+
+class PostWhereFilter extends QueryFilter
+{
+    public function title($value)
+    {
+        $this->where('title', 'like', "%$value%");
+    }
+
+    public function age($value)
+    {
+        $this->where('age', '>=', $value);
+    }
+}

--- a/tests/QueryFilterTest.php
+++ b/tests/QueryFilterTest.php
@@ -81,6 +81,30 @@ class QueryFilterTest extends TestCase
         $this->assertempty($builder->getQuery()->wheres);
     }
 
+    public function testCallingBuilderMethods()
+    {
+        $builder = $this->makeBuilder(Filters\PostWhereFilter::class);
+
+        $expected = [
+            [
+                "type" => "Basic",
+                "column" => "title",
+                "operator" => "like",
+                "value" => "%foo%",
+                "boolean" => "and",
+            ],
+            [
+                "type" => "Basic",
+                "column" => "age",
+                "operator" => ">=",
+                "value" => 18,
+                "boolean" => "and",
+            ],
+        ];
+
+        $this->assertArraySubset($expected, $builder->getQuery()->wheres);
+    }
+
     /**
      * @return Request
      */
@@ -93,6 +117,7 @@ class QueryFilterTest extends TestCase
             'content' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nemo, adipisci!',
             'category' => 'bar',
             'is_long' => null,
+            'age' => 18,
         ]);
 
         return $request;

--- a/tests/QueryFilterTest.php
+++ b/tests/QueryFilterTest.php
@@ -81,6 +81,9 @@ class QueryFilterTest extends TestCase
         $this->assertempty($builder->getQuery()->wheres);
     }
 
+    /**
+     * @return Request
+     */
     protected function makeRequest()
     {
         $request = new Request;
@@ -95,11 +98,15 @@ class QueryFilterTest extends TestCase
         return $request;
     }
 
-    protected function makeBuilder($classname)
+    /**
+     * @param $className
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function makeBuilder($className)
     {
         $request = $this->makeRequest();
 
-        $filters = new $classname($request);
+        $filters = new $className($request);
 
         return Models\Post::filter($filters);
     }


### PR DESCRIPTION
Hey, thanks for the package. It's really useful!

These changes make possible to use `Builder` methods like `QueryFilter` methods, using `__call()` and like you wrote on #6.

```php
public function age($value)
{
    $this->where('age', '>=', $value);
}
```

OBS: tests included and passing.

Cheers, JG.