### PR TITLE
Improve usage according method parameters

### DIFF
--- a/src/QueryFilter.php
+++ b/src/QueryFilter.php
@@ -43,7 +43,7 @@ abstract class QueryFilter
     public function apply(Builder $builder)
     {
         $this->builder = $builder;
-        
+
         if (empty($this->filters()) && method_exists($this, 'default')) {
             call_user_func([$this, 'default']);
         }
@@ -111,19 +111,11 @@ abstract class QueryFilter
         }
 
         $method = new ReflectionMethod($this, $methodName);
+        /** @var ReflectionParameter $parameter */
+        $parameter = Arr::first($method->getParameters());
 
-        if ($value) {
-            return $method->getNumberOfParameters() > 0;
-        }
-
-        if ($method->getNumberOfParameters() > 0) {
-            /** @var ReflectionParameter $parameter */
-            $parameter = Arr::first($method->getParameters());
-
-            return $parameter->isDefaultValueAvailable();
-        }
-
-        return true;
+        return $value ? $method->getNumberOfParameters() > 0 :
+            $parameter === null || $parameter->isDefaultValueAvailable();
     }
 
     /**
@@ -137,6 +129,4 @@ abstract class QueryFilter
             return call_user_func_array([$this->builder, $name], $arguments);
         }
     }
-
-
 }

--- a/src/QueryFilter.php
+++ b/src/QueryFilter.php
@@ -4,7 +4,9 @@ namespace Kblais\QueryFilter;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use ReflectionMethod;
+use ReflectionParameter;
 
 abstract class QueryFilter
 {
@@ -107,11 +109,17 @@ abstract class QueryFilter
             return false;
         }
 
+        $value = array_filter([$value]);
         $method = new ReflectionMethod($this, $methodName);
 
-        return array_filter([$value]) ?
-            $method->getNumberOfParameters() > 0 :
-            $method->getNumberOfParameters() === 0;
+        if ($value) { // positive value for valid parameter
+            return $method->getNumberOfParameters() > 0;
+        }
+
+        /** @var ReflectionParameter $parameter */
+        $parameter = Arr::first($method->getParameters());
+
+        return $parameter && $parameter->isDefaultValueAvailable();
     }
 
     /**

--- a/tests/Filters/PostOptionalParameter.php
+++ b/tests/Filters/PostOptionalParameter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kblais\QueryFilter\Tests\Filters;
+
+use Kblais\QueryFilter\QueryFilter;
+
+class PostOptionalParameter extends QueryFilter
+{
+    public function category($value = 'foo')
+    {
+        $this->where('category', '=', $value);
+    }
+}

--- a/tests/QueryFilterTest.php
+++ b/tests/QueryFilterTest.php
@@ -115,7 +115,7 @@ class QueryFilterTest extends TestCase
         $this->assertEmpty($builder->getQuery()->wheres);
     }
 
-    public function testEmptyValuesAreAllowedIfIsOptionalParameter()
+    public function testEmptyValuesAreAllowedIfThereIsAnOptionalParameter()
     {
         $request = new Request;
         $request->merge(['category' => '']);

--- a/tests/QueryFilterTest.php
+++ b/tests/QueryFilterTest.php
@@ -105,6 +105,16 @@ class QueryFilterTest extends TestCase
         $this->assertArraySubset($expected, $builder->getQuery()->wheres);
     }
 
+    public function testCannotAcceptEmptyValues()
+    {
+        $request = new Request;
+        $request->merge(['category' => '']);
+
+        $builder = $this->makeBuilder(Filters\PostTwoFilters::class, $request);
+
+        $this->assertEmpty($builder->getQuery()->wheres);
+    }
+
     /**
      * @return Request
      */
@@ -125,11 +135,12 @@ class QueryFilterTest extends TestCase
 
     /**
      * @param $className
+     * @param Request $request
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function makeBuilder($className)
+    protected function makeBuilder($className, Request $request = null)
     {
-        $request = $this->makeRequest();
+        $request = $request ?: $this->makeRequest();
 
         $filters = new $className($request);
 

--- a/tests/QueryFilterTest.php
+++ b/tests/QueryFilterTest.php
@@ -105,7 +105,7 @@ class QueryFilterTest extends TestCase
         $this->assertArraySubset($expected, $builder->getQuery()->wheres);
     }
 
-    public function testCannotAcceptEmptyValues()
+    public function testCannotAcceptEmptyValuesIfAParameterIsRequired()
     {
         $request = new Request;
         $request->merge(['category' => '']);
@@ -113,6 +113,27 @@ class QueryFilterTest extends TestCase
         $builder = $this->makeBuilder(Filters\PostTwoFilters::class, $request);
 
         $this->assertEmpty($builder->getQuery()->wheres);
+    }
+
+    public function testEmptyValuesAreAllowedIfIsOptionalParameter()
+    {
+        $request = new Request;
+        $request->merge(['category' => '']);
+
+        $builder = $this->makeBuilder(Filters\PostOptionalParameter::class, $request);
+
+        $expected = [
+            [
+                "type" => "Basic",
+                "column" => "category",
+                "operator" => "=",
+                "value" => "foo",
+                "boolean" => "and",
+            ],
+        ];
+
+        $this->assertNotEmpty($builder->getQuery()->wheres);
+        $this->assertArraySubset($expected, $builder->getQuery()->wheres);
     }
 
     /**


### PR DESCRIPTION
Do not allow calling filter methods if there's no value and if the method requires a parameter. 

For example, sending the URL `?title=` with empty title:

```php
public function title($name) // This method won't be called anymore
{
    return $this->where('title', $name);
}
```

But, it'll be called if the `$name` parameter has an optional value or if there's no parameter:

```php
public function title($name = 'foo')
{
    return $this->where('title', $name);
}

// or

public function title()
{
    return $this->where('title', $name);
}
```
